### PR TITLE
removed clickoutside hooks from calendar element

### DIFF
--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -37,7 +37,7 @@ export default class Calendar extends React.Component {
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
     monthsShown: PropTypes.number,
-    onClickOutside: PropTypes.func.isRequired,
+    onMouseDown: PropTypes.func.isRequired,
     onMonthChange: PropTypes.func,
     forceShowMonthNavigation: PropTypes.bool,
     onDropdownFocus: PropTypes.func,
@@ -84,10 +84,6 @@ export default class Calendar extends React.Component {
         date: this.localizeMoment(nextProps.openToDate)
       })
     }
-  }
-
-  handleClickOutside = (event) => {
-    this.props.onClickOutside(event)
   }
 
   handleDropdownFocus = (event) => {
@@ -305,7 +301,7 @@ export default class Calendar extends React.Component {
 
   render () {
     return (
-      <div className={classnames('react-datepicker', this.props.className)}>
+      <div className={classnames('react-datepicker', this.props.className)} onMouseDown={this.props.onMouseDown}>
         <div className="react-datepicker__triangle" />
         {this.renderPreviousMonthButton()}
         {this.renderNextMonthButton()}

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -2,13 +2,8 @@ import Calendar from './calendar'
 import React from 'react'
 import PropTypes from 'prop-types'
 import TetherComponent from './tether_component'
-import classnames from 'classnames'
 import { isSameDay, isDayDisabled, isDayInRange, getEffectiveMinDate, getEffectiveMaxDate, parseDate, safeDateFormat } from './date_utils'
 import moment from 'moment'
-import onClickOutside from 'react-onclickoutside'
-
-var outsideClickIgnoreClass = 'react-datepicker-ignore-onclickoutside'
-var WrappedCalendar = onClickOutside(Calendar)
 
 /**
  * General datepicker component.
@@ -47,7 +42,6 @@ export default class DatePicker extends React.Component {
     onBlur: PropTypes.func,
     onChange: PropTypes.func.isRequired,
     onSelect: PropTypes.func,
-    onClickOutside: PropTypes.func,
     onChangeRaw: PropTypes.func,
     onFocus: PropTypes.func,
     onMonthChange: PropTypes.func,
@@ -89,7 +83,6 @@ export default class DatePicker extends React.Component {
       onFocus () {},
       onBlur () {},
       onSelect () {},
-      onClickOutside () {},
       onMonthChange () {},
       popoverAttachment: 'top left',
       popoverTargetAttachment: 'bottom left',
@@ -173,6 +166,7 @@ export default class DatePicker extends React.Component {
   deferFocusInput = () => {
     this.cancelFocusInput()
     this.inputFocusTimeout = window.setTimeout(() => this.setFocus(), 1)
+    this.refocus = false
   }
 
   handleDropdownFocus = () => {
@@ -180,17 +174,16 @@ export default class DatePicker extends React.Component {
   }
 
   handleBlur = (event) => {
-    if (this.state.open) {
+    if (this.state.open && this.refocus) {
       this.deferFocusInput()
     } else {
+      this.setOpen(false)
       this.props.onBlur(event)
     }
   }
 
-  handleCalendarClickOutside = (event) => {
-    this.setOpen(false)
-    this.props.onClickOutside(event)
-    if (this.props.withPortal) { event.preventDefault() }
+  handleCalendarMouseDown = (event) => {
+    this.refocus = true
   }
 
   handleChange = (event) => {
@@ -330,7 +323,7 @@ export default class DatePicker extends React.Component {
     if (!this.props.inline && (!this.state.open || this.props.disabled)) {
       return null
     }
-    return <WrappedCalendar
+    return <Calendar
         ref="calendar"
         locale={this.props.locale}
         dateFormat={this.props.dateFormatCalendar}
@@ -347,7 +340,7 @@ export default class DatePicker extends React.Component {
         endDate={this.props.endDate}
         excludeDates={this.props.excludeDates}
         filterDate={this.props.filterDate}
-        onClickOutside={this.handleCalendarClickOutside}
+        onMouseDown={this.handleCalendarMouseDown}
         highlightDates={this.props.highlightDates}
         includeDates={this.props.includeDates}
         inline={this.props.inline}
@@ -359,21 +352,16 @@ export default class DatePicker extends React.Component {
         scrollableYearDropdown={this.props.scrollableYearDropdown}
         todayButton={this.props.todayButton}
         utcOffset={this.props.utcOffset}
-        outsideClickIgnoreClass={outsideClickIgnoreClass}
         fixedHeight={this.props.fixedHeight}
         monthsShown={this.props.monthsShown}
         onDropdownFocus={this.handleDropdownFocus}
         onMonthChange={this.props.onMonthChange}
         className={this.props.calendarClassName}>
       {this.props.children}
-    </WrappedCalendar>
+    </Calendar>
   }
 
   renderDateInput = () => {
-    var className = classnames(this.props.className, {
-      [outsideClickIgnoreClass]: this.state.open
-    })
-
     const customInput = this.props.customInput || <input type="text" />
     const inputValue =
       typeof this.props.value === 'string' ? this.props.value
@@ -394,7 +382,7 @@ export default class DatePicker extends React.Component {
       placeholder: this.props.placeholderText,
       disabled: this.props.disabled,
       autoComplete: this.props.autoComplete,
-      className: className,
+      className: this.props.className,
       title: this.props.title,
       readOnly: this.props.readOnly,
       required: this.props.required,


### PR DESCRIPTION
NOTE: This PR is incomplete and more of a proof of concept.

Clickoutside is not native and does not play nice with any clicks that invoke `stopPropagation`. This is especially apparent when using `react-select` and `react-datepicker` on the same page.

Instead of refocusing after every blur of the datepicker input and only hiding the calendar `onClickOutside`, we can hide the calendar when the datepicker is blurred except in the case where the blur is caused by a calendar `mousedown` where we set a flag that tells the datepicker to refocus and continue to show the calendar.